### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/router/analysis.py
+++ b/router/analysis.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 import joblib
 import pandas as pd
+import logging
 
+logging.basicConfig(level=logging.ERROR)
 router = APIRouter(prefix="/api/analysis", tags=["analysis"])
 
 @router.get("/sectoral-options")
@@ -25,4 +27,5 @@ def analyze_sectoral_options():
         ]
         return {"recommendedStocks": recommended_stocks}
     except Exception as e:
-        return {"error": f"Failed to load model: {str(e)}"}
+        logging.error("Failed to load model", exc_info=True)
+        return {"error": "An internal error has occurred. Please try again later."}


### PR DESCRIPTION
Potential fix for [https://github.com/selftrader/tradingbot/security/code-scanning/1](https://github.com/selftrader/tradingbot/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using a logging library to log the exception details and modifying the return statement to provide a generic error message.

1. Import the `logging` module to enable logging of exception details.
2. Configure the logging settings if not already configured.
3. Replace the return statement in the exception block to log the detailed error message and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
